### PR TITLE
Splunkclient go versions

### DIFF
--- a/build/go.mod
+++ b/build/go.mod
@@ -1,4 +1,4 @@
-module github.com/signalfx/splunk-otel-go/build
+module github.com/unionai/splunk-otel-go/build
 
 go 1.21
 

--- a/build/main.go
+++ b/build/main.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	dirBuild          = "build"
-	repoPackagePrefix = "github.com/signalfx/splunk-otel-go"
+	repoPackagePrefix = "github.com/unionai/splunk-otel-go"
 )
 
 var flagSkipDocker = flag.Bool("skip-docker", false, "skip tasks and tests using Docker")

--- a/distro/example_test.go
+++ b/distro/example_test.go
@@ -17,7 +17,7 @@ package distro_test
 import (
 	"context"
 
-	"github.com/signalfx/splunk-otel-go/distro"
+	"github.com/unionai/splunk-otel-go/distro"
 )
 
 func Example() {

--- a/distro/go.mod
+++ b/distro/go.mod
@@ -1,4 +1,4 @@
-module github.com/signalfx/splunk-otel-go/distro
+module github.com/unionai/splunk-otel-go/distro
 
 go 1.20
 

--- a/distro/otel_test.go
+++ b/distro/otel_test.go
@@ -44,7 +44,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 
-	"github.com/signalfx/splunk-otel-go/distro"
+	"github.com/unionai/splunk-otel-go/distro"
 )
 
 const (

--- a/example/go.mod
+++ b/example/go.mod
@@ -1,10 +1,10 @@
-module github.com/signalfx/splunk-otel-go/example
+module github.com/unionai/splunk-otel-go/example
 
 go 1.20
 
 require (
-	github.com/signalfx/splunk-otel-go/distro v1.13.0
-	github.com/signalfx/splunk-otel-go/instrumentation/net/http/splunkhttp v1.13.0
+	github.com/unionai/splunk-otel-go/distro v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/net/http/splunkhttp v1.13.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.48.0
 	golang.org/x/sync v0.6.0
 )
@@ -46,6 +46,6 @@ require (
 	google.golang.org/protobuf v1.32.0 // indirect
 )
 
-replace github.com/signalfx/splunk-otel-go/distro => ../distro
+replace github.com/unionai/splunk-otel-go/distro => ../distro
 
-replace github.com/signalfx/splunk-otel-go/instrumentation/net/http/splunkhttp => ../instrumentation/net/http/splunkhttp
+replace github.com/unionai/splunk-otel-go/instrumentation/net/http/splunkhttp => ../instrumentation/net/http/splunkhttp

--- a/example/main.go
+++ b/example/main.go
@@ -34,8 +34,8 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/signalfx/splunk-otel-go/distro"
-	"github.com/signalfx/splunk-otel-go/instrumentation/net/http/splunkhttp"
+	"github.com/unionai/splunk-otel-go/distro"
+	"github.com/unionai/splunk-otel-go/instrumentation/net/http/splunkhttp"
 )
 
 const address = "localhost:8080"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/signalfx/splunk-otel-go
+module github.com/unionai/splunk-otel-go
 
 go 1.20
 

--- a/instrumentation/database/sql/splunksql/config.go
+++ b/instrumentation/database/sql/splunksql/config.go
@@ -28,12 +28,12 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql/internal/moniker"
-	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql/internal/moniker"
+	"github.com/unionai/splunk-otel-go/instrumentation/internal"
 )
 
 // instrumentationName is the instrumentation library identifier for a Tracer.
-const instrumentationName = "github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
+const instrumentationName = "github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
 
 // config contains configuration options.
 type config struct {

--- a/instrumentation/database/sql/splunksql/config_test.go
+++ b/instrumentation/database/sql/splunksql/config_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql/internal/moniker"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql/internal/moniker"
 )
 
 func TestURLDNSParse(t *testing.T) {

--- a/instrumentation/database/sql/splunksql/conn.go
+++ b/instrumentation/database/sql/splunksql/conn.go
@@ -22,7 +22,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql/internal/moniker"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql/internal/moniker"
 )
 
 type otelConn struct {

--- a/instrumentation/database/sql/splunksql/example_sql_test.go
+++ b/instrumentation/database/sql/splunksql/example_sql_test.go
@@ -18,7 +18,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
 )
 
 func ExampleRegister() {

--- a/instrumentation/database/sql/splunksql/example_test.go
+++ b/instrumentation/database/sql/splunksql/example_test.go
@@ -21,7 +21,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
 )
 
 const (

--- a/instrumentation/database/sql/splunksql/go.mod
+++ b/instrumentation/database/sql/splunksql/go.mod
@@ -1,9 +1,9 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql
+module github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql
 
 go 1.20
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.23.1
 	go.opentelemetry.io/otel/metric v1.23.1
@@ -18,4 +18,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../internal
+replace github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../internal

--- a/instrumentation/database/sql/splunksql/internal/moniker/moniker.go
+++ b/instrumentation/database/sql/splunksql/internal/moniker/moniker.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package moniker provides consistent identifiers for telemetry data.
-package moniker // import "github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql/internal/moniker"
+package moniker // import "github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql/internal/moniker"
 
 // Span is the name of an OpenTelemetry Span.
 type Span string

--- a/instrumentation/database/sql/splunksql/metrics.go
+++ b/instrumentation/database/sql/splunksql/metrics.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package splunksql // import "github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
+package splunksql // import "github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
 
 import (
 	"context"

--- a/instrumentation/database/sql/splunksql/sql.go
+++ b/instrumentation/database/sql/splunksql/sql.go
@@ -26,7 +26,7 @@
 //     The maximum number of open connections allowed
 //   - db.client.connections.wait_time (ms) -
 //     The time it took to obtain an open connection from the pool
-package splunksql // import "github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
+package splunksql // import "github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
 
 import (
 	"context"

--- a/instrumentation/database/sql/splunksql/stmt.go
+++ b/instrumentation/database/sql/splunksql/stmt.go
@@ -21,7 +21,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql/internal/moniker"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql/internal/moniker"
 )
 
 // otelStmt is traced sql.Stmt.

--- a/instrumentation/database/sql/splunksql/test/db_metrics_test.go
+++ b/instrumentation/database/sql/splunksql/test/db_metrics_test.go
@@ -28,7 +28,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
 )
 
 func TestMetrics(t *testing.T) { //nolint:funlen // the want is big
@@ -78,7 +78,7 @@ func TestMetrics(t *testing.T) { //nolint:funlen // the want is big
 			wantPoolAttr := attribute.String("pool.name", tc.wantPoolName)
 			want := metricdata.ScopeMetrics{
 				Scope: instrumentation.Scope{
-					Name:      "github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql",
+					Name:      "github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql",
 					Version:   splunksql.Version(),
 					SchemaURL: semconv.SchemaURL,
 				},

--- a/instrumentation/database/sql/splunksql/test/doc.go
+++ b/instrumentation/database/sql/splunksql/test/doc.go
@@ -18,4 +18,4 @@ This package is in a separate module from the instrumentation it tests to
 isolate the dependency of the default SDK and not impose this as a transitive
 dependency for users.
 */
-package test // import "github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql/test"
+package test // import "github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql/test"

--- a/instrumentation/database/sql/splunksql/test/go.mod
+++ b/instrumentation/database/sql/splunksql/test/go.mod
@@ -1,9 +1,9 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql/test
+module github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql/test
 
 go 1.20
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql v1.13.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.23.1
 	go.opentelemetry.io/otel/sdk v1.23.1
@@ -18,13 +18,13 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
 	go.opentelemetry.io/otel/metric v1.23.1 // indirect
 	golang.org/x/sys v0.17.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace (
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql => ../
-	github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../internal
+	github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql => ../
+	github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../internal
 )

--- a/instrumentation/database/sql/splunksql/test/suite_test.go
+++ b/instrumentation/database/sql/splunksql/test/suite_test.go
@@ -27,8 +27,8 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	traceapi "go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql/internal/moniker"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql/internal/moniker"
 )
 
 // SplunkSQLSuite is the tracing test suite for the splunksql package.

--- a/instrumentation/database/sql/splunksql/tx.go
+++ b/instrumentation/database/sql/splunksql/tx.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"database/sql/driver"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql/internal/moniker"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql/internal/moniker"
 )
 
 // otelTx is a traced version of sql.Tx

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/carrier_test.go
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/carrier_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka"
 )
 
 const (

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/config.go
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/config.go
@@ -24,11 +24,11 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
+	"github.com/unionai/splunk-otel-go/instrumentation/internal"
 )
 
 // instrumentationName is the instrumentation library identifier for a Tracer.
-const instrumentationName = "github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka"
+const instrumentationName = "github.com/unionai/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka"
 
 func newConfig(options ...Option) *internal.Config {
 	o := append([]internal.Option{internal.OptionFunc(func(c *internal.Config) {

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/consumer.go
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/consumer.go
@@ -32,7 +32,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
+	"github.com/unionai/splunk-otel-go/instrumentation/internal"
 )
 
 // Consumer wraps a kafka.Consumer and traces its operations.

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/doc.go
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/doc.go
@@ -14,4 +14,4 @@
 
 // Package splunkkafka provides functions to trace the
 // github.com/confluentinc/confluent-kafka-go/kafka package.
-package splunkkafka // import "github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka"
+package splunkkafka // import "github.com/unionai/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka"

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/example_test.go
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/example_test.go
@@ -21,7 +21,7 @@ package splunkkafka_test
 import (
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka"
 )
 
 func ExampleNewConsumer() {

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/go.mod
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/go.mod
@@ -1,10 +1,10 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka
 
 go 1.20
 
 require (
 	github.com/confluentinc/confluent-kafka-go v1.9.2
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.23.1
 	go.opentelemetry.io/otel/trace v1.23.1
@@ -19,4 +19,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../../internal
+replace github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../../internal

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/producer.go
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/producer.go
@@ -29,7 +29,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
+	"github.com/unionai/splunk-otel-go/instrumentation/internal"
 )
 
 // A Producer wraps a kafka.Producer and traces its operations.

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/test/go.mod
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/test/go.mod
@@ -1,11 +1,11 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/test
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/test
 
 go 1.20
 
 require (
 	github.com/confluentinc/confluent-kafka-go v1.9.2
 	github.com/ory/dockertest/v3 v3.10.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka v1.13.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.23.1
 	go.opentelemetry.io/otel/sdk v1.23.1
@@ -36,7 +36,7 @@ require (
 	github.com/opencontainers/runc v1.1.12 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
@@ -50,6 +50,6 @@ require (
 )
 
 replace (
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka => ../
-	github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../../../internal
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka => ../
+	github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../../../internal
 )

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/test/kafka_test.go
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka/test/kafka_test.go
@@ -37,7 +37,7 @@ import (
 	traceapi "go.opentelemetry.io/otel/trace"
 	"go.uber.org/goleak"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka"
 )
 
 var (

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/carrier_test.go
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/carrier_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka"
 )
 
 const (

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/config.go
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/config.go
@@ -24,11 +24,11 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
+	"github.com/unionai/splunk-otel-go/instrumentation/internal"
 )
 
 // instrumentationName is the instrumentation library identifier for a Tracer.
-const instrumentationName = "github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka"
+const instrumentationName = "github.com/unionai/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka"
 
 func newConfig(options ...Option) *internal.Config {
 	o := append([]internal.Option{internal.OptionFunc(func(c *internal.Config) {

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/consumer.go
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/consumer.go
@@ -32,7 +32,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
+	"github.com/unionai/splunk-otel-go/instrumentation/internal"
 )
 
 // Consumer wraps a kafka.Consumer and traces its operations.

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/doc.go
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/doc.go
@@ -14,4 +14,4 @@
 
 // Package splunkkafka provides functions to trace the
 // github.com/confluentinc/confluent-kafka-go/v2/kafka package.
-package splunkkafka // import "github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka"
+package splunkkafka // import "github.com/unionai/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka"

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/example_test.go
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/example_test.go
@@ -21,7 +21,7 @@ package splunkkafka_test
 import (
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka"
 )
 
 func ExampleNewConsumer() {

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/go.mod
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/go.mod
@@ -1,10 +1,10 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka
 
 go 1.20
 
 require (
 	github.com/confluentinc/confluent-kafka-go/v2 v2.3.0
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.23.1
 	go.opentelemetry.io/otel/trace v1.23.1
@@ -19,4 +19,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../../../internal
+replace github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../../../internal

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/producer.go
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/producer.go
@@ -29,7 +29,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
+	"github.com/unionai/splunk-otel-go/instrumentation/internal"
 )
 
 // A Producer wraps a kafka.Producer and traces its operations.

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/test/go.mod
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/test/go.mod
@@ -1,11 +1,11 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/test
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/test
 
 go 1.20
 
 require (
 	github.com/confluentinc/confluent-kafka-go/v2 v2.3.0
 	github.com/ory/dockertest/v3 v3.10.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka v1.13.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.23.1
 	go.opentelemetry.io/otel/sdk v1.23.1
@@ -40,7 +40,7 @@ require (
 	github.com/opencontainers/runc v1.1.12 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
@@ -54,6 +54,6 @@ require (
 )
 
 replace (
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka => ../
-	github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../../../../internal
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka => ../
+	github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../../../../internal
 )

--- a/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/test/kafka_test.go
+++ b/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka/test/kafka_test.go
@@ -37,7 +37,7 @@ import (
 	traceapi "go.opentelemetry.io/otel/trace"
 	"go.uber.org/goleak"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka"
 )
 
 var (

--- a/instrumentation/github.com/go-chi/chi/splunkchi/chi.go
+++ b/instrumentation/github.com/go-chi/chi/splunkchi/chi.go
@@ -26,11 +26,11 @@ import (
 	"go.opentelemetry.io/otel/semconv/v1.17.0/httpconv"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
+	"github.com/unionai/splunk-otel-go/instrumentation/internal"
 )
 
 // instrumentationName is the instrumentation library identifier for a Tracer.
-const instrumentationName = "github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi"
+const instrumentationName = "github.com/unionai/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi"
 
 // Middleware returns github.com/go-chi/chi middleware that traces served
 // requests.

--- a/instrumentation/github.com/go-chi/chi/splunkchi/example_test.go
+++ b/instrumentation/github.com/go-chi/chi/splunkchi/example_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/go-chi/chi"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi"
 )
 
 func Example() {

--- a/instrumentation/github.com/go-chi/chi/splunkchi/go.mod
+++ b/instrumentation/github.com/go-chi/chi/splunkchi/go.mod
@@ -1,10 +1,10 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi
 
 go 1.20
 
 require (
 	github.com/go-chi/chi v1.5.5
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0
 	go.opentelemetry.io/otel v1.23.1
 	go.opentelemetry.io/otel/trace v1.23.1
 )
@@ -15,4 +15,4 @@ require (
 	go.opentelemetry.io/otel/metric v1.23.1 // indirect
 )
 
-replace github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../internal
+replace github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../internal

--- a/instrumentation/github.com/go-chi/chi/splunkchi/option.go
+++ b/instrumentation/github.com/go-chi/chi/splunkchi/option.go
@@ -19,7 +19,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
+	"github.com/unionai/splunk-otel-go/instrumentation/internal"
 )
 
 func localToInternal(opts []Option) []internal.Option {

--- a/instrumentation/github.com/go-chi/chi/splunkchi/test/chi_test.go
+++ b/instrumentation/github.com/go-chi/chi/splunkchi/test/chi_test.go
@@ -38,7 +38,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	traceapi "go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi"
 )
 
 func newTestServer(tp *trace.TracerProvider) *chi.Mux {

--- a/instrumentation/github.com/go-chi/chi/splunkchi/test/go.mod
+++ b/instrumentation/github.com/go-chi/chi/splunkchi/test/go.mod
@@ -1,10 +1,10 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi/test
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi/test
 
 go 1.20
 
 require (
 	github.com/go-chi/chi v1.5.5
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi v1.13.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.23.1
 	go.opentelemetry.io/otel/sdk v1.23.1
@@ -16,13 +16,13 @@ require (
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
 	go.opentelemetry.io/otel/metric v1.23.1 // indirect
 	golang.org/x/sys v0.17.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace (
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi => ../
-	github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../../internal
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/go-chi/chi/splunkchi => ../
+	github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../../internal
 )

--- a/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/example_test.go
+++ b/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/example_test.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
-	_ "github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
+	_ "github.com/unionai/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql"
 )
 
 type server struct {

--- a/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/go.mod
+++ b/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/go.mod
@@ -1,10 +1,10 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql
 
 go 1.20
 
 require (
 	github.com/go-sql-driver/mysql v1.7.1
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql v1.13.0
 	github.com/stretchr/testify v1.8.4
 )
 
@@ -13,7 +13,7 @@ require (
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
 	go.opentelemetry.io/otel v1.23.1 // indirect
 	go.opentelemetry.io/otel/metric v1.23.1 // indirect
 	go.opentelemetry.io/otel/trace v1.23.1 // indirect
@@ -21,6 +21,6 @@ require (
 )
 
 replace (
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql => ../../../../database/sql/splunksql
-	github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../internal
+	github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql => ../../../../database/sql/splunksql
+	github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../internal
 )

--- a/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/sql.go
+++ b/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/sql.go
@@ -31,8 +31,8 @@
 // Update to this.
 //
 //	import (
-//		_ "github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql"
-//		"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
+//		_ "github.com/unionai/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql"
+//		"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
 //	)
 //	// ...
 //	db, err := splunksql.Open("mysql", "user:password@/dbname")
@@ -46,7 +46,7 @@ import (
 	// Make sure to import this so the instrumented driver is registered.
 	"github.com/go-sql-driver/mysql"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
 )
 
 func init() { //nolint: gochecknoinits // register db driver

--- a/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/sql_test.go
+++ b/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/sql_test.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql"
 )
 
 func TestDSNParser(t *testing.T) {

--- a/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/test/go.mod
+++ b/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/test/go.mod
@@ -1,11 +1,11 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/test
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/test
 
 go 1.20
 
 require (
 	github.com/ory/dockertest/v3 v3.10.0
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.13.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql v1.13.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.23.1
 	go.opentelemetry.io/otel/sdk v1.23.1
@@ -35,7 +35,7 @@ require (
 	github.com/opencontainers/runc v1.1.12 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
@@ -50,7 +50,7 @@ require (
 )
 
 replace (
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql => ../../../../../database/sql/splunksql
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql => ../
-	github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../../internal
+	github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql => ../../../../../database/sql/splunksql
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql => ../
+	github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../../internal
 )

--- a/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/test/integration_test.go
+++ b/instrumentation/github.com/go-sql-driver/mysql/splunkmysql/test/integration_test.go
@@ -35,8 +35,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
-	_ "github.com/signalfx/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
+	_ "github.com/unionai/splunk-otel-go/instrumentation/github.com/go-sql-driver/mysql/splunkmysql"
 )
 
 const (

--- a/instrumentation/github.com/gomodule/redigo/splunkredigo/example_test.go
+++ b/instrumentation/github.com/gomodule/redigo/splunkredigo/example_test.go
@@ -23,8 +23,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo/option"
-	splunkredis "github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo/redis"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo/option"
+	splunkredis "github.com/unionai/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo/redis"
 )
 
 func Example() {

--- a/instrumentation/github.com/gomodule/redigo/splunkredigo/go.mod
+++ b/instrumentation/github.com/gomodule/redigo/splunkredigo/go.mod
@@ -1,10 +1,10 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo
 
 go 1.20
 
 require (
 	github.com/gomodule/redigo v1.8.9
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.23.1
 	go.opentelemetry.io/otel/trace v1.23.1
@@ -19,4 +19,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../internal
+replace github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../internal

--- a/instrumentation/github.com/gomodule/redigo/splunkredigo/option/option.go
+++ b/instrumentation/github.com/gomodule/redigo/splunkredigo/option/option.go
@@ -20,7 +20,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
+	"github.com/unionai/splunk-otel-go/instrumentation/internal"
 )
 
 // Option applies options to a configuration.

--- a/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/conn.go
+++ b/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/conn.go
@@ -27,12 +27,12 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
-	splunkredigo "github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo"
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo/option"
-	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
+	splunkredigo "github.com/unionai/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo/option"
+	"github.com/unionai/splunk-otel-go/instrumentation/internal"
 )
 
-const instrumentationName = "github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo"
+const instrumentationName = "github.com/unionai/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo"
 
 type otelConn struct {
 	redis.Conn

--- a/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/dial.go
+++ b/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/dial.go
@@ -27,7 +27,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/semconv/v1.17.0/netconv"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo/option"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo/option"
 )
 
 // Dial dials into the network address and returns a traced redis.Conn. The

--- a/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/test/go.mod
+++ b/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/test/go.mod
@@ -1,11 +1,11 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/test
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/test
 
 go 1.20
 
 require (
 	github.com/gomodule/redigo v1.8.9
 	github.com/ory/dockertest v3.3.5+incompatible
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo v1.13.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.23.1
 	go.opentelemetry.io/otel/sdk v1.23.1
@@ -30,7 +30,7 @@ require (
 	github.com/opencontainers/runc v1.1.12 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	go.opentelemetry.io/otel/metric v1.23.1 // indirect
 	golang.org/x/mod v0.15.0 // indirect
@@ -42,6 +42,6 @@ require (
 )
 
 replace (
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo => ../..
-	github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../../../internal
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo => ../..
+	github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../../../internal
 )

--- a/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/test/redis_test.go
+++ b/instrumentation/github.com/gomodule/redigo/splunkredigo/redis/test/redis_test.go
@@ -39,9 +39,9 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	traceapi "go.opentelemetry.io/otel/trace"
 
-	splunkredigo "github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo"
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo/option"
-	splunkredis "github.com/signalfx/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo/redis"
+	splunkredigo "github.com/unionai/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo/option"
+	splunkredis "github.com/unionai/splunk-otel-go/instrumentation/github.com/gomodule/redigo/splunkredigo/redis"
 )
 
 var addr string

--- a/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/example_test.go
+++ b/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/example_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql"
 )
 
 const schema = `

--- a/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/go.mod
+++ b/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/go.mod
@@ -1,10 +1,10 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql
 
 go 1.20
 
 require (
 	github.com/graph-gophers/graphql-go v1.5.0
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0
 	go.opentelemetry.io/otel v1.23.1
 	go.opentelemetry.io/otel/trace v1.23.1
 )
@@ -15,4 +15,4 @@ require (
 	go.opentelemetry.io/otel/metric v1.23.1 // indirect
 )
 
-replace github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../internal
+replace github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../internal

--- a/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/graphql.go
+++ b/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/graphql.go
@@ -26,11 +26,11 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	oteltrace "go.opentelemetry.io/otel/trace"
 
-	gql "github.com/signalfx/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/internal"
-	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
+	gql "github.com/unionai/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/internal"
+	"github.com/unionai/splunk-otel-go/instrumentation/internal"
 )
 
-const instrumentationName = "github.com/signalfx/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql"
+const instrumentationName = "github.com/unionai/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql"
 
 // otelTracer implements the graphql-go/trace.Tracer interface using
 // OpenTelemetry.

--- a/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/option.go
+++ b/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/option.go
@@ -18,7 +18,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
+	"github.com/unionai/splunk-otel-go/instrumentation/internal"
 )
 
 func localToInternal(opts []Option) []internal.Option {

--- a/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/test/go.mod
+++ b/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/test/go.mod
@@ -1,10 +1,10 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/test
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/test
 
 go 1.20
 
 require (
 	github.com/graph-gophers/graphql-go v1.5.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql v1.13.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel/sdk v1.23.1
 	go.opentelemetry.io/otel/trace v1.23.1
@@ -15,7 +15,7 @@ require (
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
 	go.opentelemetry.io/otel v1.23.1 // indirect
 	go.opentelemetry.io/otel/metric v1.23.1 // indirect
 	golang.org/x/sys v0.17.0 // indirect
@@ -23,6 +23,6 @@ require (
 )
 
 replace (
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql => ../
-	github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../../internal
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql => ../
+	github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../../internal
 )

--- a/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/test/graphql_test.go
+++ b/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/test/graphql_test.go
@@ -38,8 +38,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	traceapi "go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql"
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/internal"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql/internal"
 )
 
 const testSchema = `

--- a/instrumentation/github.com/jackc/pgx/splunkpgx/example_test.go
+++ b/instrumentation/github.com/jackc/pgx/splunkpgx/example_test.go
@@ -21,10 +21,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
 
 	// Make sure to import this so the instrumented driver is registered.
-	_ "github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx"
+	_ "github.com/unionai/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx"
 )
 
 type server struct {

--- a/instrumentation/github.com/jackc/pgx/splunkpgx/go.mod
+++ b/instrumentation/github.com/jackc/pgx/splunkpgx/go.mod
@@ -1,10 +1,10 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx
 
 go 1.20
 
 require (
 	github.com/jackc/pgx/v4 v4.18.1
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql v1.13.0
 	github.com/stretchr/testify v1.8.4
 )
 
@@ -20,7 +20,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 // indirect
 	github.com/jackc/pgtype v1.14.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
 	go.opentelemetry.io/otel v1.23.1 // indirect
 	go.opentelemetry.io/otel/metric v1.23.1 // indirect
 	go.opentelemetry.io/otel/trace v1.23.1 // indirect
@@ -30,6 +30,6 @@ require (
 )
 
 replace (
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql => ../../../../database/sql/splunksql
-	github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../internal
+	github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql => ../../../../database/sql/splunksql
+	github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../internal
 )

--- a/instrumentation/github.com/jackc/pgx/splunkpgx/sql.go
+++ b/instrumentation/github.com/jackc/pgx/splunkpgx/sql.go
@@ -31,8 +31,8 @@
 // Update to this.
 //
 //	import (
-//		_ "github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx"
-//		"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
+//		_ "github.com/unionai/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx"
+//		"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
 //	)
 //	// ...
 //	db, err := splunksql.Open("pgx", "postgres://localhost:5432/dbname")
@@ -48,7 +48,7 @@ import (
 	// Make sure to import this so the instrumented driver is registered.
 	_ "github.com/jackc/pgx/v4/stdlib"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
 )
 
 func init() { //nolint: gochecknoinits // register db driver

--- a/instrumentation/github.com/jackc/pgx/splunkpgx/sql_test.go
+++ b/instrumentation/github.com/jackc/pgx/splunkpgx/sql_test.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx"
 )
 
 func TestDSNParser(t *testing.T) {

--- a/instrumentation/github.com/jackc/pgx/splunkpgx/test/go.mod
+++ b/instrumentation/github.com/jackc/pgx/splunkpgx/test/go.mod
@@ -1,11 +1,11 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx/test
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx/test
 
 go 1.20
 
 require (
 	github.com/ory/dockertest/v3 v3.10.0
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.13.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx v1.13.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.23.1
 	go.opentelemetry.io/otel/sdk v1.23.1
@@ -42,7 +42,7 @@ require (
 	github.com/opencontainers/runc v1.1.12 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
@@ -59,7 +59,7 @@ require (
 )
 
 replace (
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql => ../../../../../database/sql/splunksql
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx => ../
-	github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../../internal
+	github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql => ../../../../../database/sql/splunksql
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx => ../
+	github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../../internal
 )

--- a/instrumentation/github.com/jackc/pgx/splunkpgx/test/integration_test.go
+++ b/instrumentation/github.com/jackc/pgx/splunkpgx/test/integration_test.go
@@ -35,8 +35,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
-	_ "github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
+	_ "github.com/unionai/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx"
 )
 
 const (

--- a/instrumentation/github.com/jackc/pgx/v5/splunkpgx/example_test.go
+++ b/instrumentation/github.com/jackc/pgx/v5/splunkpgx/example_test.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
 )
 
 type server struct {

--- a/instrumentation/github.com/jackc/pgx/v5/splunkpgx/go.mod
+++ b/instrumentation/github.com/jackc/pgx/v5/splunkpgx/go.mod
@@ -1,10 +1,10 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/v5/splunkpgx
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/jackc/pgx/v5/splunkpgx
 
 go 1.20
 
 require (
 	github.com/jackc/pgx/v5 v5.5.3
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql v1.13.0
 	github.com/stretchr/testify v1.8.4
 )
 
@@ -18,7 +18,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
 	go.opentelemetry.io/otel v1.23.1 // indirect
 	go.opentelemetry.io/otel/metric v1.23.1 // indirect
 	go.opentelemetry.io/otel/trace v1.23.1 // indirect
@@ -29,6 +29,6 @@ require (
 )
 
 replace (
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql => ../../../../../database/sql/splunksql
-	github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../../internal
+	github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql => ../../../../../database/sql/splunksql
+	github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../../internal
 )

--- a/instrumentation/github.com/jackc/pgx/v5/splunkpgx/sql.go
+++ b/instrumentation/github.com/jackc/pgx/v5/splunkpgx/sql.go
@@ -31,8 +31,8 @@
 // Update to this.
 //
 //	import (
-//		_ "github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/v5/splunkpgx"
-//		"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
+//		_ "github.com/unionai/splunk-otel-go/instrumentation/github.com/jackc/pgx/v5/splunkpgx"
+//		"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
 //	)
 //	// ...
 //	db, err := splunksql.Open("pgx", "postgres://localhost:5432/dbname")
@@ -48,7 +48,7 @@ import (
 	// Make sure to import this so the instrumented driver is registered.
 	_ "github.com/jackc/pgx/v5/stdlib"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
 )
 
 func init() { //nolint: gochecknoinits // register db driver

--- a/instrumentation/github.com/jackc/pgx/v5/splunkpgx/sql_test.go
+++ b/instrumentation/github.com/jackc/pgx/v5/splunkpgx/sql_test.go
@@ -17,11 +17,11 @@ package splunkpgx_test
 import (
 	"testing"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/v5/splunkpgx"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/jackc/pgx/v5/splunkpgx"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
 )
 
 func TestDSNParser(t *testing.T) {

--- a/instrumentation/github.com/jackc/pgx/v5/splunkpgx/test/go.mod
+++ b/instrumentation/github.com/jackc/pgx/v5/splunkpgx/test/go.mod
@@ -1,11 +1,11 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/v5/splunkpgx/test
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/jackc/pgx/v5/splunkpgx/test
 
 go 1.20
 
 require (
 	github.com/ory/dockertest/v3 v3.10.0
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.13.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/v5/splunkpgx v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/jackc/pgx/v5/splunkpgx v1.13.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.23.1
 	go.opentelemetry.io/otel/sdk v1.23.1
@@ -39,7 +39,7 @@ require (
 	github.com/opencontainers/runc v1.1.12 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
@@ -57,7 +57,7 @@ require (
 )
 
 replace (
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql => ../../../../../../database/sql/splunksql
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/v5/splunkpgx => ../
-	github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../../../internal
+	github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql => ../../../../../../database/sql/splunksql
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/jackc/pgx/v5/splunkpgx => ../
+	github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../../../internal
 )

--- a/instrumentation/github.com/jackc/pgx/v5/splunkpgx/test/integration_test.go
+++ b/instrumentation/github.com/jackc/pgx/v5/splunkpgx/test/integration_test.go
@@ -35,8 +35,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
-	_ "github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/v5/splunkpgx"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
+	_ "github.com/unionai/splunk-otel-go/instrumentation/github.com/jackc/pgx/v5/splunkpgx"
 )
 
 const (

--- a/instrumentation/github.com/jinzhu/gorm/splunkgorm/example_test.go
+++ b/instrumentation/github.com/jinzhu/gorm/splunkgorm/example_test.go
@@ -19,12 +19,12 @@ import (
 
 	"github.com/jinzhu/gorm"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/jinzhu/gorm/splunkgorm"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/jinzhu/gorm/splunkgorm"
 )
 
 func ExampleOpen() {
 	// This assumes the instrumented driver,
-	// "github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx",
+	// "github.com/unionai/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx",
 	// is imported. That will ensure the driver and the instrumentation setup
 	// for the driver are registered with the appropriate packages.
 	db, err := splunkgorm.Open("pgx", "postgres://localhost/db")

--- a/instrumentation/github.com/jinzhu/gorm/splunkgorm/go.mod
+++ b/instrumentation/github.com/jinzhu/gorm/splunkgorm/go.mod
@@ -1,10 +1,10 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/jinzhu/gorm/splunkgorm
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/jinzhu/gorm/splunkgorm
 
 go 1.20
 
 require (
 	github.com/jinzhu/gorm v1.9.16
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql v1.13.0
 	github.com/stretchr/testify v1.8.4
 )
 
@@ -14,7 +14,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
 	go.opentelemetry.io/otel v1.23.1 // indirect
 	go.opentelemetry.io/otel/metric v1.23.1 // indirect
 	go.opentelemetry.io/otel/trace v1.23.1 // indirect
@@ -22,6 +22,6 @@ require (
 )
 
 replace (
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql => ../../../../database/sql/splunksql
-	github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../internal
+	github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql => ../../../../database/sql/splunksql
+	github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../internal
 )

--- a/instrumentation/github.com/jinzhu/gorm/splunkgorm/sql.go
+++ b/instrumentation/github.com/jinzhu/gorm/splunkgorm/sql.go
@@ -14,12 +14,12 @@
 
 // Package splunkgorm provides instrumentation for the [github.com/jinzhu/gorm]
 // package.
-package splunkgorm // import "github.com/signalfx/splunk-otel-go/instrumentation/github.com/jinzhu/gorm/splunkgorm"
+package splunkgorm // import "github.com/unionai/splunk-otel-go/instrumentation/github.com/jinzhu/gorm/splunkgorm"
 
 import (
 	"github.com/jinzhu/gorm"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
 )
 
 // openFunc allows overrides for testing.

--- a/instrumentation/github.com/jinzhu/gorm/splunkgorm/sql_test.go
+++ b/instrumentation/github.com/jinzhu/gorm/splunkgorm/sql_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
 )
 
 type mockOpen struct {

--- a/instrumentation/github.com/jmoiron/sqlx/splunksqlx/example_test.go
+++ b/instrumentation/github.com/jmoiron/sqlx/splunksqlx/example_test.go
@@ -19,12 +19,12 @@ import (
 
 	"github.com/jmoiron/sqlx"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/jmoiron/sqlx/splunksqlx"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/jmoiron/sqlx/splunksqlx"
 )
 
 func ExampleOpen() {
 	// This assumes the instrumented driver,
-	// "github.com/signalfx/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx",
+	// "github.com/unionai/splunk-otel-go/instrumentation/github.com/jackc/pgx/splunkpgx",
 	// is imported. That will ensure the driver and the instrumentation setup
 	// for the driver are registered with the appropriate packages.
 	db, err := splunksqlx.Open("pgx", "postgres://localhost/db")

--- a/instrumentation/github.com/jmoiron/sqlx/splunksqlx/go.mod
+++ b/instrumentation/github.com/jmoiron/sqlx/splunksqlx/go.mod
@@ -1,10 +1,10 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/jmoiron/sqlx/splunksqlx
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/jmoiron/sqlx/splunksqlx
 
 go 1.20
 
 require (
 	github.com/jmoiron/sqlx v1.3.5
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql v1.13.0
 	github.com/stretchr/testify v1.8.4
 )
 
@@ -13,7 +13,7 @@ require (
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
 	go.opentelemetry.io/otel v1.23.1 // indirect
 	go.opentelemetry.io/otel/metric v1.23.1 // indirect
 	go.opentelemetry.io/otel/trace v1.23.1 // indirect
@@ -21,6 +21,6 @@ require (
 )
 
 replace (
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql => ../../../../database/sql/splunksql
-	github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../internal
+	github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql => ../../../../database/sql/splunksql
+	github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../internal
 )

--- a/instrumentation/github.com/jmoiron/sqlx/splunksqlx/sql.go
+++ b/instrumentation/github.com/jmoiron/sqlx/splunksqlx/sql.go
@@ -14,12 +14,12 @@
 
 // Package splunksqlx provides instrumentation for the [github.com/jmoiron/sqlx]
 // package.
-package splunksqlx // import "github.com/signalfx/splunk-otel-go/instrumentation/github.com/jmoiron/sqlx/splunksqlx"
+package splunksqlx // import "github.com/unionai/splunk-otel-go/instrumentation/github.com/jmoiron/sqlx/splunksqlx"
 
 import (
 	"github.com/jmoiron/sqlx"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
 )
 
 // openFunc allows overrides for testing.

--- a/instrumentation/github.com/jmoiron/sqlx/splunksqlx/sql_test.go
+++ b/instrumentation/github.com/jmoiron/sqlx/splunksqlx/sql_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
 )
 
 type mockOpen struct {

--- a/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/example_test.go
+++ b/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/example_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/julienschmidt/httprouter"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter"
 )
 
 func Index(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {

--- a/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/go.mod
+++ b/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/go.mod
@@ -1,4 +1,4 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter
 
 go 1.20
 

--- a/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/test/go.mod
+++ b/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/test/go.mod
@@ -1,10 +1,10 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/test
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/test
 
 go 1.20
 
 require (
 	github.com/julienschmidt/httprouter v1.3.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter v1.13.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.48.0
 	go.opentelemetry.io/otel v1.23.1
@@ -23,4 +23,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/signalfx/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter => ../
+replace github.com/unionai/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter => ../

--- a/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/test/httprouter_test.go
+++ b/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter/test/httprouter_test.go
@@ -29,7 +29,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter"
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/stretchr/testify/assert"

--- a/instrumentation/github.com/lib/pq/splunkpq/example_test.go
+++ b/instrumentation/github.com/lib/pq/splunkpq/example_test.go
@@ -21,10 +21,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
 
 	// Make sure to import this so the instrumented driver is registered.
-	_ "github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq"
+	_ "github.com/unionai/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq"
 )
 
 type server struct {

--- a/instrumentation/github.com/lib/pq/splunkpq/go.mod
+++ b/instrumentation/github.com/lib/pq/splunkpq/go.mod
@@ -1,10 +1,10 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq
 
 go 1.20
 
 require (
 	github.com/lib/pq v1.10.9
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql v1.13.0
 	github.com/stretchr/testify v1.8.4
 )
 
@@ -13,7 +13,7 @@ require (
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
 	go.opentelemetry.io/otel v1.23.1 // indirect
 	go.opentelemetry.io/otel/metric v1.23.1 // indirect
 	go.opentelemetry.io/otel/trace v1.23.1 // indirect
@@ -21,6 +21,6 @@ require (
 )
 
 replace (
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql => ../../../../database/sql/splunksql
-	github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../internal
+	github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql => ../../../../database/sql/splunksql
+	github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../internal
 )

--- a/instrumentation/github.com/lib/pq/splunkpq/sql.go
+++ b/instrumentation/github.com/lib/pq/splunkpq/sql.go
@@ -31,8 +31,8 @@
 // Update to this.
 //
 //	import (
-//		_ "github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq"
-//		"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
+//		_ "github.com/unionai/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq"
+//		"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
 //	)
 //	// ...
 //	db, err := splunksql.Open("postgres", "postgres://localhost:5432/dbname")
@@ -49,8 +49,8 @@ import (
 	// Make sure to import this so the instrumented driver is registered.
 	_ "github.com/lib/pq"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq/internal"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq/internal"
 )
 
 func init() { //nolint: gochecknoinits // register db driver

--- a/instrumentation/github.com/lib/pq/splunkpq/sql_test.go
+++ b/instrumentation/github.com/lib/pq/splunkpq/sql_test.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq"
 )
 
 func TestDSNParser(t *testing.T) {

--- a/instrumentation/github.com/lib/pq/splunkpq/test/go.mod
+++ b/instrumentation/github.com/lib/pq/splunkpq/test/go.mod
@@ -1,17 +1,17 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq/test
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq/test
 
 go 1.20
 
 replace (
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql => ../../../../../database/sql/splunksql
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq => ../
-	github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../../internal
+	github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql => ../../../../../database/sql/splunksql
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq => ../
+	github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../../internal
 )
 
 require (
 	github.com/ory/dockertest/v3 v3.10.0
-	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.13.0
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq v1.13.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.23.1
 	go.opentelemetry.io/otel/sdk v1.23.1
@@ -41,7 +41,7 @@ require (
 	github.com/opencontainers/runc v1.1.12 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/instrumentation/github.com/lib/pq/splunkpq/test/integration_test.go
+++ b/instrumentation/github.com/lib/pq/splunkpq/test/integration_test.go
@@ -35,8 +35,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
-	_ "github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq"
+	"github.com/unionai/splunk-otel-go/instrumentation/database/sql/splunksql"
+	_ "github.com/unionai/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq"
 )
 
 const (

--- a/instrumentation/github.com/miekg/dns/splunkdns/client.go
+++ b/instrumentation/github.com/miekg/dns/splunkdns/client.go
@@ -21,7 +21,7 @@ import (
 	"github.com/miekg/dns"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
+	"github.com/unionai/splunk-otel-go/instrumentation/internal"
 )
 
 // A Client wraps a DNS Client so that requests are traced.

--- a/instrumentation/github.com/miekg/dns/splunkdns/dns.go
+++ b/instrumentation/github.com/miekg/dns/splunkdns/dns.go
@@ -22,7 +22,7 @@ import (
 	"github.com/miekg/dns"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
+	"github.com/unionai/splunk-otel-go/instrumentation/internal"
 )
 
 // ListenAndServe wraps the passed handler so all requests it servers are

--- a/instrumentation/github.com/miekg/dns/splunkdns/example_test.go
+++ b/instrumentation/github.com/miekg/dns/splunkdns/example_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/miekg/dns"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns"
 )
 
 func Example_client() {

--- a/instrumentation/github.com/miekg/dns/splunkdns/go.mod
+++ b/instrumentation/github.com/miekg/dns/splunkdns/go.mod
@@ -1,10 +1,10 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns
 
 go 1.20
 
 require (
 	github.com/miekg/dns v1.1.58
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0
 	go.opentelemetry.io/otel v1.23.1
 	go.opentelemetry.io/otel/trace v1.23.1
 )
@@ -19,4 +19,4 @@ require (
 	golang.org/x/tools v0.18.0 // indirect
 )
 
-replace github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../internal
+replace github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../internal

--- a/instrumentation/github.com/miekg/dns/splunkdns/handler.go
+++ b/instrumentation/github.com/miekg/dns/splunkdns/handler.go
@@ -21,7 +21,7 @@ import (
 	"github.com/miekg/dns"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
+	"github.com/unionai/splunk-otel-go/instrumentation/internal"
 )
 
 // A Handler wraps a DNS Handler so that requests are traced.

--- a/instrumentation/github.com/miekg/dns/splunkdns/option.go
+++ b/instrumentation/github.com/miekg/dns/splunkdns/option.go
@@ -20,11 +20,11 @@ import (
 
 	"github.com/miekg/dns"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
+	"github.com/unionai/splunk-otel-go/instrumentation/internal"
 )
 
 // instrumentationName is the instrumentation library identifier for a Tracer.
-const instrumentationName = "github.com/signalfx/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns"
+const instrumentationName = "github.com/unionai/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns"
 
 // Option applies options to a configuration.
 type Option interface {

--- a/instrumentation/github.com/miekg/dns/splunkdns/test/client_test.go
+++ b/instrumentation/github.com/miekg/dns/splunkdns/test/client_test.go
@@ -29,7 +29,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	traceapi "go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns"
 )
 
 var defaultClientAttrs = []attribute.KeyValue{

--- a/instrumentation/github.com/miekg/dns/splunkdns/test/go.mod
+++ b/instrumentation/github.com/miekg/dns/splunkdns/test/go.mod
@@ -1,10 +1,10 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns/test
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns/test
 
 go 1.20
 
 require (
 	github.com/miekg/dns v1.1.58
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns v1.13.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.23.1
 	go.opentelemetry.io/otel/sdk v1.23.1
@@ -16,7 +16,7 @@ require (
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
 	go.opentelemetry.io/otel/metric v1.23.1 // indirect
 	golang.org/x/mod v0.15.0 // indirect
 	golang.org/x/net v0.21.0 // indirect
@@ -26,6 +26,6 @@ require (
 )
 
 replace (
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns => ../
-	github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../../internal
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns => ../
+	github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../../internal
 )

--- a/instrumentation/github.com/miekg/dns/splunkdns/test/handler_test.go
+++ b/instrumentation/github.com/miekg/dns/splunkdns/test/handler_test.go
@@ -28,7 +28,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	traceapi "go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/miekg/dns/splunkdns"
 )
 
 var defaultServerAttrs = []attribute.KeyValue{

--- a/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/config.go
+++ b/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/config.go
@@ -21,11 +21,11 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
+	"github.com/unionai/splunk-otel-go/instrumentation/internal"
 )
 
 // instrumentationName is the instrumentation library identifier for a Tracer.
-const instrumentationName = "github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb"
+const instrumentationName = "github.com/unionai/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb"
 
 // config contains tracing configuration options.
 type config struct {

--- a/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/example_test.go
+++ b/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/example_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/storage"
 	"go.opentelemetry.io/otel"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb"
 )
 
 func Example() {

--- a/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/go.mod
+++ b/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/go.mod
@@ -1,9 +1,9 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb
 
 go 1.20
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0
 	github.com/stretchr/testify v1.8.4
 	github.com/syndtr/goleveldb v1.0.0
 	go.opentelemetry.io/otel v1.23.1
@@ -21,4 +21,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../../internal
+replace github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../../internal

--- a/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/test/go.mod
+++ b/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/test/go.mod
@@ -1,9 +1,9 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/test
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/test
 
 go 1.20
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb v1.13.0
 	github.com/stretchr/testify v1.8.4
 	github.com/syndtr/goleveldb v1.0.0
 	go.opentelemetry.io/otel v1.23.1
@@ -17,13 +17,13 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
 	go.opentelemetry.io/otel/metric v1.23.1 // indirect
 	golang.org/x/sys v0.17.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace (
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb => ../
-	github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../../../internal
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb => ../
+	github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../../../internal
 )

--- a/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/test/splunkleveldb_test.go
+++ b/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb/test/splunkleveldb_test.go
@@ -33,7 +33,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	traceapi "go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb"
 )
 
 var expectedValue = []byte("world")

--- a/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/config.go
+++ b/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/config.go
@@ -21,11 +21,11 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
+	"github.com/unionai/splunk-otel-go/instrumentation/internal"
 )
 
 // instrumentationName is the instrumentation library identifier for a Tracer.
-const instrumentationName = "github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb"
+const instrumentationName = "github.com/unionai/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb"
 
 type config struct {
 	*internal.Config

--- a/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/example_test.go
+++ b/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/example_test.go
@@ -17,7 +17,7 @@ package splunkbuntdb_test
 import (
 	"fmt"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb"
 )
 
 func Example() {

--- a/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/go.mod
+++ b/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/go.mod
@@ -1,9 +1,9 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb
 
 go 1.20
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0
 	github.com/stretchr/testify v1.8.4
 	github.com/tidwall/buntdb v1.3.0
 	go.opentelemetry.io/otel v1.23.1
@@ -26,4 +26,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../internal
+replace github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../internal

--- a/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/test/buntdb_test.go
+++ b/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/test/buntdb_test.go
@@ -30,7 +30,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	traceapi "go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb"
+	"github.com/unionai/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb"
 )
 
 func TestAscend(t *testing.T) {

--- a/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/test/go.mod
+++ b/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/test/go.mod
@@ -1,9 +1,9 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/test
+module github.com/unionai/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb/test
 
 go 1.20
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb v1.13.0
 	github.com/stretchr/testify v1.8.4
 	github.com/tidwall/buntdb v1.3.0
 	go.opentelemetry.io/otel v1.23.1
@@ -16,7 +16,7 @@ require (
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
 	github.com/tidwall/btree v1.7.0 // indirect
 	github.com/tidwall/gjson v1.17.1 // indirect
 	github.com/tidwall/grect v0.1.4 // indirect
@@ -30,6 +30,6 @@ require (
 )
 
 replace (
-	github.com/signalfx/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb => ../
-	github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../../internal
+	github.com/unionai/splunk-otel-go/instrumentation/github.com/tidwall/buntdb/splunkbuntdb => ../
+	github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../../internal
 )

--- a/instrumentation/gopkg.in/olivere/elastic/splunkelastic/elastic.go
+++ b/instrumentation/gopkg.in/olivere/elastic/splunkelastic/elastic.go
@@ -26,11 +26,11 @@ import (
 	"go.opentelemetry.io/otel/semconv/v1.17.0/httpconv"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
+	"github.com/unionai/splunk-otel-go/instrumentation/internal"
 )
 
 // instrumentationName is the instrumentation library identifier for a Tracer.
-const instrumentationName = "github.com/signalfx/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic"
+const instrumentationName = "github.com/unionai/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic"
 
 // WrapRoundTripper returns an http.RoundTripper that wraps the passed rt. All
 // requests handled by the returned http.RoundTripper will be traced with the

--- a/instrumentation/gopkg.in/olivere/elastic/splunkelastic/example_test.go
+++ b/instrumentation/gopkg.in/olivere/elastic/splunkelastic/example_test.go
@@ -21,7 +21,7 @@ import (
 	elasticv7 "github.com/olivere/elastic/v7"
 	elasticv3 "gopkg.in/olivere/elastic.v3"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic"
+	"github.com/unionai/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic"
 )
 
 func Example() {

--- a/instrumentation/gopkg.in/olivere/elastic/splunkelastic/go.mod
+++ b/instrumentation/gopkg.in/olivere/elastic/splunkelastic/go.mod
@@ -1,10 +1,10 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic
+module github.com/unionai/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic
 
 go 1.20
 
 require (
 	github.com/olivere/elastic/v7 v7.0.32
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.23.1
 	go.opentelemetry.io/otel/trace v1.23.1
@@ -24,4 +24,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../internal
+replace github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../internal

--- a/instrumentation/gopkg.in/olivere/elastic/splunkelastic/option.go
+++ b/instrumentation/gopkg.in/olivere/elastic/splunkelastic/option.go
@@ -19,7 +19,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
+	"github.com/unionai/splunk-otel-go/instrumentation/internal"
 )
 
 // Option applies options to a configuration.

--- a/instrumentation/gopkg.in/olivere/elastic/splunkelastic/test/elastic_test.go
+++ b/instrumentation/gopkg.in/olivere/elastic/splunkelastic/test/elastic_test.go
@@ -41,7 +41,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	apitrace "go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic"
+	"github.com/unionai/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic"
 )
 
 var addr string

--- a/instrumentation/gopkg.in/olivere/elastic/splunkelastic/test/go.mod
+++ b/instrumentation/gopkg.in/olivere/elastic/splunkelastic/test/go.mod
@@ -1,11 +1,11 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic/test
+module github.com/unionai/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic/test
 
 go 1.20
 
 require (
 	github.com/olivere/elastic/v7 v7.0.32
 	github.com/ory/dockertest v3.3.5+incompatible
-	github.com/signalfx/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic v1.13.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.23.1
 	go.opentelemetry.io/otel/sdk v1.23.1
@@ -32,7 +32,7 @@ require (
 	github.com/opencontainers/runc v1.1.12 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	go.opentelemetry.io/otel/metric v1.23.1 // indirect
 	golang.org/x/mod v0.15.0 // indirect
@@ -44,6 +44,6 @@ require (
 )
 
 replace (
-	github.com/signalfx/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic => ../
-	github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../../internal
+	github.com/unionai/splunk-otel-go/instrumentation/gopkg.in/olivere/elastic/splunkelastic => ../
+	github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../../internal
 )

--- a/instrumentation/internal/config_test.go
+++ b/instrumentation/internal/config_test.go
@@ -30,7 +30,7 @@ import (
 	"go.opentelemetry.io/otel/trace/noop"
 )
 
-const iName = "github.com/signalfx/splunk-otel-go/instrumentation/internal"
+const iName = "github.com/unionai/splunk-otel-go/instrumentation/internal"
 
 var mockTracerProvider = func(spanRecorder map[string]*mockSpan) trace.TracerProvider {
 	recordSpan := func(s *mockSpan) {

--- a/instrumentation/internal/go.mod
+++ b/instrumentation/internal/go.mod
@@ -1,4 +1,4 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/internal
+module github.com/unionai/splunk-otel-go/instrumentation/internal
 
 go 1.20
 

--- a/instrumentation/k8s.io/client-go/splunkclient-go/go.mod
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/go.mod
@@ -3,8 +3,8 @@ module github.com/unionai/splunk-otel-go/instrumentation/k8s.io/client-go/splunk
 go 1.20
 
 require (
-	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0
 	github.com/stretchr/testify v1.8.4
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0
 	go.opentelemetry.io/otel v1.23.1
 	go.opentelemetry.io/otel/trace v1.23.1
 	k8s.io/apimachinery v0.28.4

--- a/instrumentation/k8s.io/client-go/splunkclient-go/go.mod
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/go.mod
@@ -1,9 +1,9 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go
+module github.com/unionai/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go
 
 go 1.20
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.23.1
 	go.opentelemetry.io/otel/trace v1.23.1
@@ -52,4 +52,4 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../internal
+replace github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../internal

--- a/instrumentation/k8s.io/client-go/splunkclient-go/option/option.go
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/option/option.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !(go1.1 || go1.2 || go1.3 || go1.4 || go1.5 || go1.6 || go1.7 || go1.8 || go1.9 || go1.10 || go1.11 || go1.12 || go1.13 || go1.14 || go1.15 || go1.16)
-// +build !go1.1,!go1.2,!go1.3,!go1.4,!go1.5,!go1.6,!go1.7,!go1.8,!go1.9,!go1.10,!go1.11,!go1.12,!go1.13,!go1.14,!go1.15,!go1.16
+//go:build go1.17
+// +build go1.17
 
 package option
 

--- a/instrumentation/k8s.io/client-go/splunkclient-go/option/option.go
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/option/option.go
@@ -22,7 +22,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
+	"github.com/unionai/splunk-otel-go/instrumentation/internal"
 )
 
 // Option applies options to a configuration.

--- a/instrumentation/k8s.io/client-go/splunkclient-go/transport/example_test.go
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/transport/example_test.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !(go1.1 || go1.2 || go1.3 || go1.4 || go1.5 || go1.6 || go1.7 || go1.8 || go1.9 || go1.10 || go1.11 || go1.12 || go1.13 || go1.14 || go1.15 || go1.16)
-// +build !go1.1,!go1.2,!go1.3,!go1.4,!go1.5,!go1.6,!go1.7,!go1.8,!go1.9,!go1.10,!go1.11,!go1.12,!go1.13,!go1.14,!go1.15,!go1.16
+//go:build go1.17
+// +build go1.17
 
 package transport_test
 

--- a/instrumentation/k8s.io/client-go/splunkclient-go/transport/example_test.go
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/transport/example_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go/transport"
+	"github.com/unionai/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go/transport"
 )
 
 func Example() {

--- a/instrumentation/k8s.io/client-go/splunkclient-go/transport/test/go.mod
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/transport/test/go.mod
@@ -1,9 +1,9 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go/transport/test
+module github.com/unionai/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go/transport/test
 
 go 1.20
 
 require (
-	github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go v1.13.0
+	github.com/unionai/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go v1.13.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.23.1
 	go.opentelemetry.io/otel/sdk v1.23.1
@@ -16,7 +16,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
+	github.com/unionai/splunk-otel-go/instrumentation/internal v1.13.0 // indirect
 	go.opentelemetry.io/otel/metric v1.23.1 // indirect
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/oauth2 v0.17.0 // indirect
@@ -33,6 +33,6 @@ require (
 )
 
 replace (
-	github.com/signalfx/splunk-otel-go/instrumentation/internal => ../../../../../internal
-	github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go => ../..
+	github.com/unionai/splunk-otel-go/instrumentation/internal => ../../../../../internal
+	github.com/unionai/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go => ../..
 )

--- a/instrumentation/k8s.io/client-go/splunkclient-go/transport/test/splunkclient-go_test.go
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/transport/test/splunkclient-go_test.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !(go1.1 || go1.2 || go1.3 || go1.4 || go1.5 || go1.6 || go1.7 || go1.8 || go1.9 || go1.10 || go1.11 || go1.12 || go1.13 || go1.14 || go1.15 || go1.16)
-// +build !go1.1,!go1.2,!go1.3,!go1.4,!go1.5,!go1.6,!go1.7,!go1.8,!go1.9,!go1.10,!go1.11,!go1.12,!go1.13,!go1.14,!go1.15,!go1.16
+//go:build go1.17
+// +build go1.17
 
 package test
 

--- a/instrumentation/k8s.io/client-go/splunkclient-go/transport/test/splunkclient-go_test.go
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/transport/test/splunkclient-go_test.go
@@ -34,9 +34,9 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
-	splunkclientgo "github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go"
-	"github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go/option"
-	"github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go/transport"
+	splunkclientgo "github.com/unionai/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go"
+	"github.com/unionai/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go/option"
+	"github.com/unionai/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go/transport"
 )
 
 func request(t *testing.T, handle func(http.ResponseWriter, *http.Request)) (*tracetest.SpanRecorder, *http.Response, string) {

--- a/instrumentation/k8s.io/client-go/splunkclient-go/transport/transport.go
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/transport/transport.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !(go1.1 || go1.2 || go1.3 || go1.4 || go1.5 || go1.6 || go1.7 || go1.8 || go1.9 || go1.10 || go1.11 || go1.12 || go1.13 || go1.14 || go1.15 || go1.16)
-// +build !go1.1,!go1.2,!go1.3,!go1.4,!go1.5,!go1.6,!go1.7,!go1.8,!go1.9,!go1.10,!go1.11,!go1.12,!go1.13,!go1.14,!go1.15,!go1.16
+//go:build go1.17
+// +build go1.17
 
 package transport
 

--- a/instrumentation/k8s.io/client-go/splunkclient-go/transport/transport.go
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/transport/transport.go
@@ -113,7 +113,7 @@ func (rt *roundTripper) RoundTrip(r *http.Request) (resp *http.Response, err err
 }
 
 const (
-	prefixAPI   = "/api/v1/"
+	prefixAPI   = "/apis/"
 	prefixWatch = "watch/"
 )
 

--- a/instrumentation/k8s.io/client-go/splunkclient-go/transport/transport.go
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/transport/transport.go
@@ -29,13 +29,13 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/client-go/transport"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/internal"
-	splunkclientgo "github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go"
-	"github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go/option"
+	"github.com/unionai/splunk-otel-go/instrumentation/internal"
+	splunkclientgo "github.com/unionai/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go"
+	"github.com/unionai/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go/option"
 )
 
 // instrumentationName is the instrumentation library identifier for a Tracer.
-const instrumentationName = "github.com/signalfx/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go"
+const instrumentationName = "github.com/unionai/splunk-otel-go/instrumentation/k8s.io/client-go/splunkclient-go"
 
 // NewWrapperFunc returns a Kubernetes WrapperFunc that can be used with a
 // client configuration to trace all communication the client makes.

--- a/instrumentation/k8s.io/client-go/splunkclient-go/transport/transport_test.go
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/transport/transport_test.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !(go1.1 || go1.2 || go1.3 || go1.4 || go1.5 || go1.6 || go1.7 || go1.8 || go1.9 || go1.10 || go1.11 || go1.12 || go1.13 || go1.14 || go1.15 || go1.16)
-// +build !go1.1,!go1.2,!go1.3,!go1.4,!go1.5,!go1.6,!go1.7,!go1.8,!go1.9,!go1.10,!go1.11,!go1.12,!go1.13,!go1.14,!go1.15,!go1.16
+//go:build go1.17
+// +build go1.17
 
 package transport
 

--- a/instrumentation/k8s.io/client-go/splunkclient-go/version.go
+++ b/instrumentation/k8s.io/client-go/splunkclient-go/version.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !(go1.1 || go1.2 || go1.3 || go1.4 || go1.5 || go1.6 || go1.7 || go1.8 || go1.9 || go1.10 || go1.11 || go1.12 || go1.13 || go1.14 || go1.15 || go1.16)
-// +build !go1.1,!go1.2,!go1.3,!go1.4,!go1.5,!go1.6,!go1.7,!go1.8,!go1.9,!go1.10,!go1.11,!go1.12,!go1.13,!go1.14,!go1.15,!go1.16
+//go:build go1.17
+// +build go1.17
 
 package splunkclientgo
 

--- a/instrumentation/net/http/splunkhttp/doc.go
+++ b/instrumentation/net/http/splunkhttp/doc.go
@@ -14,4 +14,4 @@
 
 // Package splunkhttp provides functions that add additional Splunk specific instrumentation
 // by wrapping existing handlers.
-package splunkhttp // import "github.com/signalfx/splunk-otel-go/instrumentation/net/http/splunkhttp"
+package splunkhttp // import "github.com/unionai/splunk-otel-go/instrumentation/net/http/splunkhttp"

--- a/instrumentation/net/http/splunkhttp/example_test.go
+++ b/instrumentation/net/http/splunkhttp/example_test.go
@@ -23,7 +23,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/sdk/trace"
 
-	"github.com/signalfx/splunk-otel-go/instrumentation/net/http/splunkhttp"
+	"github.com/unionai/splunk-otel-go/instrumentation/net/http/splunkhttp"
 )
 
 //nolint:errcheck,noctx // example usage

--- a/instrumentation/net/http/splunkhttp/go.mod
+++ b/instrumentation/net/http/splunkhttp/go.mod
@@ -1,4 +1,4 @@
-module github.com/signalfx/splunk-otel-go/instrumentation/net/http/splunkhttp
+module github.com/unionai/splunk-otel-go/instrumentation/net/http/splunkhttp
 
 go 1.20
 

--- a/version.go
+++ b/version.go
@@ -16,7 +16,7 @@
 Package splunkotel provides version information for the Splunk distribution of
 OpenTelemetry Go.
 */
-package splunkotel // import "github.com/signalfx/splunk-otel-go"
+package splunkotel // import "github.com/unionai/splunk-otel-go"
 
 // Version is the current release version of splunk-otel-go in use.
 func Version() string {

--- a/version_test.go
+++ b/version_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	splunkotel "github.com/signalfx/splunk-otel-go"
+	splunkotel "github.com/unionai/splunk-otel-go"
 )
 
 func TestVersionSemver(t *testing.T) {


### PR DESCRIPTION
## Overview
This change
* Updates all modules to `github.com/unionai/splunk-otel-go` so they can be imported
  ```
  ❯ find . -name '*.go' -exec sed -i '' 's/github.com\/signalfx\/splunk-otel-go/github.com\/unionai\/splunk-otel-go/g' {} \;
  ❯ for f in $(find . -name go.mod); do (echo $(dirname $f); go mod tidy); done
  ```
* Configures min go version to go1.17 per https://github.com/signalfx/splunk-otel-go/issues/2890
* Updates the prefix to `/apis/` to match the observed flyte CRD path

## Testing
Unittests
```
❯ for f in $(find . -name go.mod); do (echo $(dirname $f); go work use .; go test); done
```

Was able to integrate this into a union component and verify traces
<img width="1141" alt="Screenshot 2024-02-15 at 9 23 46 PM" src="https://github.com/signalfx/splunk-otel-go/assets/5725707/7d0e88d1-e094-408a-aa9a-b48e047bbdb0">
